### PR TITLE
fix(posts): resolve ONLY_FULL_GROUP_BY error in view-stats query

### DIFF
--- a/app/Services/DashboardService.php
+++ b/app/Services/DashboardService.php
@@ -92,11 +92,14 @@ class DashboardService
     {
         $postIds = (clone $postQuery)->pluck('id');
 
-        return Post::select('posts.*', DB::raw('SUM(pvs.views) as total_views'))
-            ->join('post_view_statistics as pvs', 'pvs.post_id', '=', 'posts.id')
+        $sub = DB::table('post_view_statistics')
+            ->selectRaw('post_id, SUM(views) AS total_views')
+            ->groupBy('post_id');
+
+        return Post::select('posts.*', 'agg.total_views')
+            ->joinSub($sub, 'agg', 'agg.post_id', '=', 'posts.id')
             ->whereIn('posts.id', $postIds)
-            ->groupBy('posts.id')
-            ->orderByDesc('total_views')
+            ->orderByDesc('agg.total_views')
             ->first();
     }
 


### PR DESCRIPTION
MySQL 5.7+ rejects SELECT posts.* with SUM() grouped only by posts.id. Re-implement the query using a sub-query that pre-aggregates views, then JOIN it to posts. This keeps ONLY_FULL_GROUP_BY enabled while returning the same result set (top post by total views). Also short-circuit when
 is empty to avoid useless queries.